### PR TITLE
remove -g from express and koajs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Name |  PIP Install | Repository | License
 ## Web framework for Node.js
 Name | NPM Install | Repository | License
 --- | --- | --- | ---
-[Express.js](http://expressjs.com/)| \[sudo\] npm install -g express | https://github.com/visionmedia/express| [MIT](http://opensource.org/licenses/MIT)
+[Express.js](http://expressjs.com/)| \[sudo\] npm install express | https://github.com/visionmedia/express| [MIT](http://opensource.org/licenses/MIT)
 [Flatiron](http://flatironjs.org/)| \[sudo\] npm install -g flatiron| https://github.com/flatiron|[MIT](http://opensource.org/licenses/MIT)
 [Hapi](http://spumko.github.io/)| npm install hapi | https://github.com/spumko/hapi| Unknown
 [partial.js](http://www.partialjs.com/)| \[sudo\] npm install -g partial.js| https://github.com/petersirka/partial.js| [MIT](http://opensource.org/licenses/MIT) 
-[koa](https://github.com/koajs/koa)| \[sudo\] npm install -g koajs | https://github.com/koajs/koa | [MIT](http://opensource.org/licenses/MIT)
+[koa](https://github.com/koajs/koa)| \[sudo\] npm install koajs | https://github.com/koajs/koa | [MIT](http://opensource.org/licenses/MIT)
 
 ## Web framework for Ruby
 Name | Gem Install | Repository | License


### PR DESCRIPTION
we're removing global installs for express in the next version, and koa doesn't support -g. not sure about the other frameworks.
