### PR TITLE
Fixed formatting issues for Ruby frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,9 @@ Name |  PIP Install | Repository | License
 ## Web framework for Ruby
 Name | Gem Install | Repository | License
 --- | --- | --- | ---
-=======
-[Cuba](http://cuba.is/)| gem install cuba | https://github.com/soveran/cuba | [MIT](http://opensource.org/licenses/MIT)
-[Padrino](http://www.padrinorb.com/)| gem install padrino | https://github.com/padrino/padrino-framework | [MIT](http://opensource.org/licenses/MIT)
-[Sinatra](http://www.sinatrarb.com/)| gem install sinatra | https://github.com/sinatra/sinatra/ | [MIT](http://opensource.org/licenses/MIT)
-=======
+[Cuba](http://cuba.is/) | gem install cuba | https://github.com/soveran/cuba | [MIT](http://opensource.org/licenses/MIT)
+[Padrino](http://www.padrinorb.com/) | gem install padrino | https://github.com/padrino/padrino-framework | [MIT](http://opensource.org/licenses/MIT)
+[Sinatra](http://www.sinatrarb.com/) | gem install sinatra | https://github.com/sinatra/sinatra/ | [MIT](http://opensource.org/licenses/MIT)
 
 ## Web framework for PHP
 Name | Repository | License


### PR DESCRIPTION
Ruby framework list currently looks like this:
![screenshot 2013-12-17 17 58 40](https://f.cloud.github.com/assets/426630/1770263/f9351c18-6787-11e3-9614-f054e75ca084.png)
