### PR TITLE
Add Crepe to Ruby web frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Name | Gem Install | Repository | License
 [Camping](http://camping.io/) | gem install camping | http://github.com/camping/camping | [MIT](http://opensource.org/licenses/MIT)
 [Cuba](http://cuba.is/) | gem install cuba | https://github.com/soveran/cuba | [MIT](http://opensource.org/licenses/MIT)
 [Grape](http://intridea.github.io/grape) | gem install grape | https://github.com/intridea/grape | [MIT](http://opensource.org/licenses/MIT)
+[Crepe](https://github.com/stephencelis/crepe) | gem install crepe | https://github.com/stephencelis/crepe | [MIT](http://opensource.org/licenses/MIT)
 [Hobbit](https://github.com/patriciomacadden/hobbit) | gem install hobbit | https://github.com/patriciomacadden/hobbit | [MIT](http://opensource.org/licenses/MIT)
 [Kenji](https://github.com/kballenegger/kenji) | gem install kenji | https://github.com/kballenegger/Kenji | [Azure](http://license.azuretalon.com/)
 [Nancy](http://guilleiguaran.github.io/nancy) | gem install nancy | https://github.com/guilleiguaran/nancy | [MIT](http://opensource.org/licenses/MIT)


### PR DESCRIPTION
[Crêpe](https://github.com/stephencelis/crepe) is a lightweight API stack for Ruby.
